### PR TITLE
feat: Add standalone treasure map page with shareable URL

### DIFF
--- a/app/treasure-maps/godaddy/page.tsx
+++ b/app/treasure-maps/godaddy/page.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link';
+import TreasureMap from '@/components/TreasureMap';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'GoDaddy Customer Service Treasure Map | Interactive Journey',
+  description: 'Follow the treasure map through GoDaddy\'s customer service cancellation flow - an interactive visual journey',
+  openGraph: {
+    title: 'GoDaddy Customer Service Treasure Map',
+    description: 'Follow the treasure map through GoDaddy\'s customer service cancellation flow',
+    images: ['/images/godaddy/godaddy-1.png'],
+  },
+};
+
+const godaddyImages = [
+  {
+    src: '/images/godaddy/godaddy-1.png',
+    alt: 'Step 1',
+    position: { top: '50px', left: '40px' }
+  },
+  {
+    src: '/images/godaddy/godaddy-2.png',
+    alt: 'Step 2',
+    position: { top: '350px', right: '50px' }
+  },
+  {
+    src: '/images/godaddy/godaddy-3.png',
+    alt: 'Step 3',
+    position: { top: '750px', left: '80px' }
+  },
+  {
+    src: '/images/godaddy/godaddy-4.png',
+    alt: 'Step 4',
+    position: { top: '1250px', right: '70px' }
+  },
+  {
+    src: '/images/godaddy/godaddy-5.png',
+    alt: 'Step 5 - The End',
+    position: { top: '1650px', left: '50%', transform: 'translateX(-50%)' }
+  }
+];
+
+const svgPaths = [
+  'M 200 100 Q 475 225, 750 350',
+  'M 750 350 Q 500 550, 250 750',
+  'M 250 750 Q 500 1000, 750 1250',
+  'M 750 1250 Q 650 1450, 550 1650'
+];
+
+export default function GoDaddyTreasureMap() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-gray-950 to-gray-900">
+      {/* Back link */}
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <Link
+          href="/posts/godaddy-is-cancer"
+          className="inline-flex items-center gap-2 text-red-400 hover:text-red-300 transition-colors font-medium"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M19 12H5M12 19l-7-7 7-7"/>
+          </svg>
+          Back to full blog post
+        </Link>
+      </div>
+
+      {/* Treasure Map */}
+      <div className="max-w-4xl mx-auto px-4">
+        <TreasureMap
+          images={godaddyImages}
+          paths={svgPaths}
+          title="START HERE"
+        />
+      </div>
+
+      {/* Footer note */}
+      <div className="max-w-4xl mx-auto px-4 py-8 text-center text-gray-500 text-sm">
+        <p>Interactive treasure map created with Claude Code</p>
+        <Link
+          href="/posts/godaddy-is-cancer"
+          className="text-red-400 hover:text-red-300 transition-colors mt-2 inline-block"
+        >
+          Read the full story →
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/components/TreasureMap.tsx
+++ b/components/TreasureMap.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState } from 'react';
+
+interface TreasureMapImage {
+  src: string;
+  alt: string;
+  position: {
+    top?: string;
+    left?: string;
+    right?: string;
+    transform?: string;
+  };
+}
+
+interface TreasureMapProps {
+  images: TreasureMapImage[];
+  paths: string[];
+  title?: string;
+}
+
+export default function TreasureMap({ images, paths, title = "START HERE" }: TreasureMapProps) {
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
+  const openLightbox = (src: string) => {
+    setLightboxSrc(src);
+    document.body.style.overflow = 'hidden';
+  };
+
+  const closeLightbox = () => {
+    setLightboxSrc(null);
+    document.body.style.overflow = 'auto';
+  };
+
+  return (
+    <>
+      <div className="treasure-map-container" style={{
+        position: 'relative',
+        maxWidth: '900px',
+        margin: '3rem auto',
+        padding: '2rem 1rem',
+        minHeight: '2100px',
+        background: 'linear-gradient(135deg, #1a1a1a 0%, #2a2a2a 100%)',
+        borderRadius: '16px',
+        border: '2px solid #3a3a3a'
+      }}>
+        {/* SVG Path Overlay with Multiple Arrows */}
+        <svg style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          pointerEvents: 'none',
+          zIndex: 1
+        }}>
+          <defs>
+            <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+              <polygon points="0 0, 10 3, 0 6" fill="#ef4444" />
+            </marker>
+          </defs>
+          {paths.map((d, idx) => (
+            <path
+              key={idx}
+              d={d}
+              stroke="#ef4444"
+              strokeWidth="3"
+              strokeDasharray="10,10"
+              fill="none"
+              markerEnd="url(#arrowhead)"
+              opacity="0.7"
+            />
+          ))}
+        </svg>
+
+        {/* Start Flag */}
+        <div style={{
+          position: 'absolute',
+          top: '15px',
+          left: '40px',
+          color: '#ef4444',
+          fontWeight: 'bold',
+          fontSize: '0.9rem',
+          zIndex: 2
+        }}>
+          🚩 {title}
+        </div>
+
+        {/* Images */}
+        {images.map((image, idx) => (
+          <div
+            key={idx}
+            style={{
+              position: 'absolute',
+              zIndex: 3,
+              maxWidth: '420px',
+              ...image.position
+            }}
+          >
+            <div style={{ position: 'relative' }}>
+              <div style={{
+                position: 'absolute',
+                top: '-15px',
+                left: '-15px',
+                width: '45px',
+                height: '45px',
+                background: '#ef4444',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'white',
+                fontWeight: 'bold',
+                fontSize: '1.3rem',
+                boxShadow: '0 4px 6px rgba(0,0,0,0.3)',
+                zIndex: 1
+              }}>
+                {idx + 1}
+              </div>
+              <img
+                src={image.src}
+                alt={image.alt}
+                onClick={() => openLightbox(image.src)}
+                style={{
+                  width: '100%',
+                  borderRadius: '12px',
+                  boxShadow: '0 8px 16px rgba(0,0,0,0.4)',
+                  border: '3px solid #ef4444',
+                  cursor: 'pointer',
+                  transition: 'transform 0.2s'
+                }}
+              />
+              {idx === images.length - 1 && (
+                <div style={{
+                  textAlign: 'center',
+                  marginTop: '1rem',
+                  color: '#ef4444',
+                  fontWeight: 'bold',
+                  fontSize: '1.5rem'
+                }}>
+                  ☠️ THE END ☠️
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {/* Styles */}
+        <style jsx>{`
+          .treasure-map-container img:hover {
+            transform: scale(1.05);
+          }
+
+          @media (max-width: 768px) {
+            .treasure-map-container {
+              min-height: auto !important;
+            }
+            .treasure-map-container > div[style*="position: absolute"] {
+              position: relative !important;
+              left: 0 !important;
+              right: 0 !important;
+              top: auto !important;
+              transform: none !important;
+              margin: 2rem auto !important;
+              max-width: 90% !important;
+            }
+            .treasure-map-container svg {
+              display: none;
+            }
+          }
+        `}</style>
+      </div>
+
+      {/* Lightbox Modal */}
+      {lightboxSrc && (
+        <div
+          onClick={closeLightbox}
+          onKeyDown={(e) => e.key === 'Escape' && closeLightbox()}
+          style={{
+            display: 'flex',
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            background: 'rgba(0,0,0,0.95)',
+            zIndex: 9999,
+            cursor: 'pointer',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <img
+            src={lightboxSrc}
+            alt="Enlarged view"
+            style={{
+              maxWidth: '95%',
+              maxHeight: '95%',
+              borderRadius: '8px',
+              boxShadow: '0 0 50px rgba(239, 68, 68, 0.5)'
+            }}
+          />
+          <div style={{
+            position: 'absolute',
+            top: '20px',
+            right: '30px',
+            color: 'white',
+            fontSize: '2rem',
+            fontWeight: 'bold',
+            cursor: 'pointer'
+          }}>
+            ✕
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/posts/godaddy-is-cancer.md
+++ b/posts/godaddy-is-cancer.md
@@ -26,6 +26,8 @@ Once you have your images, use a prompt like this to generate the treasure map. 
 
 Note this 'treasure map' aesthetic only makes sense on desktop, since you want zig-zagging paths / arrows connecting images.  On mobile you can just stack the images vertically.
 
+**[View standalone treasure map →](/treasure-maps/godaddy)** (easier to share!)
+
 
 <div class="treasure-map-container" style="position: relative; max-width: 1100px; margin: 3rem auto; padding: 2rem 1rem; min-height: 2100px; background: linear-gradient(135deg, #1a1a1a 0%, #2a2a2a 100%); border-radius: 16px; border: 2px solid #3a3a3a;">
 


### PR DESCRIPTION
- Create TreasureMap component from blog post HTML
  - Reusable component with lightbox functionality
  - Accepts images, SVG paths, and title as props
  - Fully responsive (zigzag on desktop, stacked on mobile)
- Add /treasure-maps/godaddy page route
  - Shareable URL: /treasure-maps/godaddy
  - Back link to blog post
  - Proper SEO metadata and OpenGraph tags
  - Max-width: 900px to match blog layout
- Update blog post with link to standalone version
  - Added "View standalone treasure map →" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)