### PR TITLE
Add sitemap validation script and local validate command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Run type check
       run: npm run type-check
 
+    - name: Check sitemap is up to date
+      run: npm run check:sitemap
+
     - name: Run unit tests
       run: npm run test:ci
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:e2e:ui": "playwright test --ui",
     "generate:rss": "tsx scripts/generate-rss.js",
     "generate:sitemap": "next-sitemap",
+    "check:sitemap": "node scripts/check-sitemap.js",
+    "validate": "npm run lint && npm run type-check && npm run check:sitemap && npm run test",
     "generate:slideshow": "node scripts/generate-slideshow.js",
     "analyze": "ANALYZE=true npm run build",
     "dev:clean": "rm -rf .next && npm run dev",

--- a/scripts/check-sitemap.js
+++ b/scripts/check-sitemap.js
@@ -1,0 +1,71 @@
+const fs = require('fs')
+const path = require('path')
+
+const SITE_URL = 'https://neonwatty.com'
+const postsDirectory = path.join(process.cwd(), 'posts')
+const sitemapPath = path.join(process.cwd(), 'public', 'sitemap.xml')
+
+function getPostSlugs() {
+  const fileNames = fs.readdirSync(postsDirectory)
+  return fileNames
+    .filter(fileName => fileName.endsWith('.md'))
+    .map(fileName => fileName.replace(/\.md$/, ''))
+}
+
+function getSitemapPostSlugs() {
+  const sitemapContent = fs.readFileSync(sitemapPath, 'utf8')
+  const postUrlPattern = new RegExp(`<loc>${SITE_URL}/posts/([^/]+)/</loc>`, 'g')
+  const slugs = []
+  let match
+
+  while ((match = postUrlPattern.exec(sitemapContent)) !== null) {
+    slugs.push(decodeURIComponent(match[1]))
+  }
+
+  return slugs
+}
+
+function checkSitemap() {
+  // Check if sitemap exists
+  if (!fs.existsSync(sitemapPath)) {
+    console.error('Sitemap not found at public/sitemap.xml')
+    console.error("Run 'npm run generate:sitemap' to create it.")
+    process.exit(1)
+  }
+
+  const postSlugs = getPostSlugs()
+  const sitemapSlugs = getSitemapPostSlugs()
+
+  const postSet = new Set(postSlugs)
+  const sitemapSet = new Set(sitemapSlugs)
+
+  // Find missing posts (in /posts/ but not in sitemap)
+  const missingFromSitemap = postSlugs.filter(slug => !sitemapSet.has(slug))
+
+  // Find stale entries (in sitemap but not in /posts/)
+  const staleInSitemap = sitemapSlugs.filter(slug => !postSet.has(slug))
+
+  if (missingFromSitemap.length === 0 && staleInSitemap.length === 0) {
+    console.log(`Sitemap is up to date (${postSlugs.length} posts)`)
+    process.exit(0)
+  }
+
+  console.error('Sitemap validation failed\n')
+
+  if (missingFromSitemap.length > 0) {
+    console.error('Missing from sitemap:')
+    missingFromSitemap.forEach(slug => console.error(`  - ${slug}`))
+    console.error('')
+  }
+
+  if (staleInSitemap.length > 0) {
+    console.error('Stale entries in sitemap:')
+    staleInSitemap.forEach(slug => console.error(`  - ${slug}`))
+    console.error('')
+  }
+
+  console.error("Run 'npm run generate:sitemap' to fix.")
+  process.exit(1)
+}
+
+checkSitemap()


### PR DESCRIPTION
## Summary
- Add `scripts/check-sitemap.js` for bidirectional sitemap validation (detects missing posts and stale entries)
- Add `check:sitemap` npm script to verify posts match sitemap
- Add `validate` npm script to run all checks locally (lint, type-check, sitemap, tests)
- Add sitemap check step to CI workflow

## Test plan
- [x] Tested `npm run check:sitemap` locally - passes with 13 posts
- [x] Tested failure detection by adding a fake post file
- [x] Tested `npm run validate` locally - all checks pass