### PR TITLE
Add daily external link check workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,30 @@
+name: Check External Links
+
+on:
+  schedule:
+    # Run daily at 9am UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps chromium
+
+    - name: Check external links
+      run: npm run check:links


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that validates external links.

- Runs daily at 9am UTC (cron schedule)
- Can be manually triggered via workflow_dispatch
- Uses `npm run check:links` to validate external links

## Test plan
- [x] Workflow file syntax is valid
- [ ] Manual trigger works after merge