### PR TITLE
Fix blog post date: 2025 → 2026

### DIFF
--- a/posts/claude-code-workflow-testing-mcp.md
+++ b/posts/claude-code-workflow-testing-mcp.md
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Browser Testing and iOS Automation with MCP Workflows"
-date: "2025-01-08"
+date: "2026-01-08"
 excerpt: "Four Claude Code skills that generate and execute user workflow tests using Claude-in-Chrome and iOS Simulator MCPs. Catch bugs and edge cases while you're still building."
 tags: ["Claude Code", "Testing", "MCP", "iOS", "Browser Automation", "AI"]
 featured: true


### PR DESCRIPTION
## Summary
- Fixed the date on the MCP workflow testing blog post from `2025-01-08` to `2026-01-08`

## Problem
The post was appearing at the bottom of the posts list because it was dated January 2025 instead of January 2026.