### PR TITLE
Fix mobile UX tap targets to meet iOS 44pt minimum

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1930,17 +1930,18 @@
   }
 }
 
-/* Improve tap targets for tag badges */
+/* Improve tap targets for tag badges - iOS requires 44pt minimum */
 .tag-badge {
-  min-height: 32px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
+  padding: 0.5rem 1rem;
 }
 
 @media (max-width: 640px) {
   .tag-badge {
-    min-height: 36px;
-    padding: 0.5rem 0.75rem;
+    min-height: 44px;
+    padding: 0.625rem 1rem;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,29 +64,33 @@ export default function Home() {
 
                 {/* Social links and Newsletter */}
                 <div className="flex flex-col sm:flex-row items-center justify-center md:justify-start gap-4 sm:gap-6">
-                  {/* Social icons */}
-                  <div className="flex gap-4"
+                  {/* Social icons - with 44px minimum tap targets for mobile */}
+                  <div className="flex gap-1"
                        style={{ color: 'var(--color-text-tertiary)' }}>
                     <a href="https://github.com/neonwatty" target="_blank" rel="noopener noreferrer"
-                       className="hover:opacity-70 transition-opacity">
+                       className="hover:opacity-70 transition-opacity p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+                       aria-label="GitHub">
                       <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                       </svg>
                     </a>
                     <a href="https://x.com/neonwatty" target="_blank" rel="noopener noreferrer"
-                       className="hover:opacity-70 transition-opacity">
+                       className="hover:opacity-70 transition-opacity p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+                       aria-label="X (Twitter)">
                       <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
                       </svg>
                     </a>
                     <a href="https://www.linkedin.com/in/jeremy-watt/" target="_blank" rel="noopener noreferrer"
-                       className="hover:opacity-70 transition-opacity">
+                       className="hover:opacity-70 transition-opacity p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+                       aria-label="LinkedIn">
                       <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                       </svg>
                     </a>
                     <a href="https://discord.gg/7xsxU4ZG6A" target="_blank" rel="noopener noreferrer"
-                       className="hover:opacity-70 transition-opacity">
+                       className="hover:opacity-70 transition-opacity p-2 min-w-[44px] min-h-[44px] flex items-center justify-center"
+                       aria-label="Discord">
                       <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 127.14 96.36">
                         <path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/>
                       </svg>

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -32,22 +32,22 @@ export default function Breadcrumbs({ items }: BreadcrumbsProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbStructuredData) }}
       />
       
-      <nav className="flex items-center space-x-2 text-sm mb-6" aria-label="Breadcrumb">
-        <ol className="flex items-center space-x-2">
+      <nav className="flex items-center text-sm mb-6" aria-label="Breadcrumb">
+        <ol className="flex items-center flex-wrap">
           {items.map((item, index) => (
             <li key={index} className="flex items-center">
               {index > 0 && (
-                <ChevronRightIcon className="w-4 h-4 mx-2 text-gray-400" aria-hidden="true" />
+                <ChevronRightIcon className="w-4 h-4 mx-1 text-gray-400 flex-shrink-0" aria-hidden="true" />
               )}
               {item.href && index < items.length - 1 ? (
                 <Link
                   href={item.href}
-                  className="text-gray-600 hover:text-blue-600 transition-colors duration-200"
+                  className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors duration-200 py-2 px-2 -mx-2 min-h-[44px] inline-flex items-center"
                 >
                   {item.label}
                 </Link>
               ) : (
-                <span className="text-gray-900 font-medium" aria-current="page">
+                <span className="text-gray-900 dark:text-gray-100 font-medium py-2 truncate max-w-[200px] sm:max-w-none" aria-current="page">
                   {item.label}
                 </span>
               )}

--- a/tests/e2e/mobile-ux.spec.ts
+++ b/tests/e2e/mobile-ux.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Mobile UX Tests
+ *
+ * These tests verify that interactive elements meet iOS Human Interface Guidelines
+ * for minimum tap target sizes (44x44 points).
+ *
+ * Reference: https://developer.apple.com/design/human-interface-guidelines/accessibility
+ */
+
+const MINIMUM_TAP_TARGET = 44
+
+// iPhone 16 viewport
+const mobileViewport = {
+  width: 393,
+  height: 852,
+}
+
+test.describe('Mobile UX - Tap Targets', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(mobileViewport)
+  })
+
+  test('social icons have minimum 44px tap targets', async ({ page }) => {
+    await page.goto('/')
+
+    // Get all social link icons in the hero section
+    const socialLinks = page.locator('a[aria-label]').filter({
+      has: page.locator('svg'),
+    })
+
+    const count = await socialLinks.count()
+    expect(count).toBeGreaterThan(0)
+
+    for (let i = 0; i < count; i++) {
+      const link = socialLinks.nth(i)
+      const box = await link.boundingBox()
+
+      if (box) {
+        expect(box.width, `Social icon ${i} width should be >= ${MINIMUM_TAP_TARGET}px`).toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+        expect(box.height, `Social icon ${i} height should be >= ${MINIMUM_TAP_TARGET}px`).toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+      }
+    }
+  })
+
+  test('tag badges have minimum 44px tap targets', async ({ page }) => {
+    // Navigate to a blog post that has tags
+    await page.goto('/posts/claude-code-workflow-testing-mcp')
+
+    // Get all tag badges
+    const tagBadges = page.locator('.tag-badge')
+
+    const count = await tagBadges.count()
+    expect(count).toBeGreaterThan(0)
+
+    for (let i = 0; i < count; i++) {
+      const badge = tagBadges.nth(i)
+      const box = await badge.boundingBox()
+
+      if (box) {
+        expect(box.height, `Tag badge ${i} height should be >= ${MINIMUM_TAP_TARGET}px`).toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+      }
+    }
+  })
+
+  test('breadcrumb links have minimum 44px tap targets', async ({ page }) => {
+    await page.goto('/posts/claude-code-workflow-testing-mcp')
+
+    // Wait for content to load
+    await page.waitForLoadState('domcontentloaded')
+
+    // Get breadcrumb navigation links - look for links within any nav with Breadcrumb aria-label
+    const breadcrumbNav = page.locator('nav[aria-label="Breadcrumb"]')
+    await expect(breadcrumbNav).toBeVisible()
+
+    const breadcrumbLinks = breadcrumbNav.locator('a')
+    const count = await breadcrumbLinks.count()
+
+    // There should be at least Home and Blog links
+    expect(count).toBeGreaterThanOrEqual(1)
+
+    for (let i = 0; i < count; i++) {
+      const link = breadcrumbLinks.nth(i)
+      const box = await link.boundingBox()
+
+      if (box) {
+        expect(box.height, `Breadcrumb link ${i} height should be >= ${MINIMUM_TAP_TARGET}px`).toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+      }
+    }
+  })
+
+  test('hamburger menu button has minimum 44px tap target', async ({ page }) => {
+    await page.goto('/')
+
+    // Get the mobile menu button
+    const menuButton = page.locator('button[aria-label*="menu"]').first()
+    await expect(menuButton).toBeVisible()
+
+    const box = await menuButton.boundingBox()
+    expect(box).toBeTruthy()
+
+    if (box) {
+      expect(box.width, 'Menu button width should be >= 44px').toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+      expect(box.height, 'Menu button height should be >= 44px').toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+    }
+  })
+
+  test('theme toggle button has minimum 44px tap target', async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Get all theme toggle buttons and find the visible one
+    const themeToggles = page.locator('button[aria-label*="Switch to"]')
+    const count = await themeToggles.count()
+
+    // Find the visible theme toggle (mobile viewport may hide desktop one)
+    let visibleToggle = null
+    for (let i = 0; i < count; i++) {
+      const toggle = themeToggles.nth(i)
+      if (await toggle.isVisible()) {
+        visibleToggle = toggle
+        break
+      }
+    }
+
+    expect(visibleToggle, 'Should find a visible theme toggle').toBeTruthy()
+
+    if (visibleToggle) {
+      const box = await visibleToggle.boundingBox()
+      expect(box).toBeTruthy()
+
+      if (box) {
+        expect(box.width, 'Theme toggle width should be >= 44px').toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+        expect(box.height, 'Theme toggle height should be >= 44px').toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+      }
+    }
+  })
+})
+
+test.describe('Mobile UX - Layout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(mobileViewport)
+  })
+
+  test('homepage has no horizontal overflow', async ({ page }) => {
+    await page.goto('/')
+
+    // Check that the body doesn't have horizontal scroll
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth
+    })
+
+    expect(hasHorizontalScroll, 'Page should not have horizontal overflow').toBe(false)
+  })
+
+  test('blog post page has no horizontal overflow', async ({ page }) => {
+    await page.goto('/posts/claude-code-workflow-testing-mcp')
+
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth
+    })
+
+    expect(hasHorizontalScroll, 'Page should not have horizontal overflow').toBe(false)
+  })
+
+  test('tag cards on tags page are touch-friendly', async ({ page }) => {
+    await page.goto('/tags')
+
+    // Get tag cards (the large clickable cards, not the small badges)
+    const tagCards = page.locator('a').filter({
+      hasText: /posts$/,
+    })
+
+    const count = await tagCards.count()
+
+    if (count > 0) {
+      const firstCard = tagCards.first()
+      const box = await firstCard.boundingBox()
+
+      if (box) {
+        // Tag cards should be significantly larger than minimum tap target
+        expect(box.height, 'Tag card should be comfortably tappable').toBeGreaterThanOrEqual(MINIMUM_TAP_TARGET)
+      }
+    }
+  })
+})
+
+test.describe('Mobile UX - Typography', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(mobileViewport)
+  })
+
+  test('body text is at least 16px', async ({ page }) => {
+    await page.goto('/posts/claude-code-workflow-testing-mcp')
+
+    // Check the prose content area
+    const proseContent = page.locator('.prose p').first()
+
+    if (await proseContent.isVisible()) {
+      const fontSize = await proseContent.evaluate((el) => {
+        return parseFloat(window.getComputedStyle(el).fontSize)
+      })
+
+      expect(fontSize, 'Body text should be at least 16px for mobile readability').toBeGreaterThanOrEqual(16)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Increases tag badge min-height to 44px with more padding for touch targets
- Adds 44px min-height to breadcrumb links with padding
- Adds 44px min tap targets to social icon links on homepage
- Adds aria-labels to social icons for accessibility
- Adds E2E tests for mobile UX tap target verification

## Changes
- `app/globals.css`: Updated tag-badge styles for 44px minimum height
- `app/page.tsx`: Added padding and aria-labels to social icons
- `components/Breadcrumbs.tsx`: Added padding and dark mode support to breadcrumb links
- `tests/e2e/mobile-ux.spec.ts`: New E2E tests for mobile tap targets

## Test plan
- [x] Verified on iPhone 16 simulator
- [x] E2E tests pass locally (9 tests)
- [ ] CI tests pass