### PR TITLE
Add GitHub Actions workflow for tag-based production releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release to Production
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel Environment
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that deploys to Vercel production when tags matching `v*` are pushed
- Creates GitHub releases with auto-generated release notes
- Uses secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID (all configured)

## How to release
```bash
git tag v1.0.0
git push origin v1.0.0
```

This enables a release strategy where:
- `main` branch = staging (auto-deployed by Vercel)
- `v*` tags = production (deployed via this workflow)