### PR TITLE
chore: switch to vercel prebuilt deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build Static Site
-        run: npm run build
+      - name: Build with Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Production
-        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- Use `vercel build --prod` instead of `npm run build`
- Use `vercel deploy --prebuilt --prod` for faster production deploys
- Matches documented workflow setup

## Test plan
- [ ] Merge PR
- [ ] Create v1.0.8 tag to trigger release workflow
- [ ] Verify build and deploy succeed