### PR TITLE
fix: add vercel pull step for prebuilt deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Link Vercel Project
         run: vercel link --yes --project blog --scope jermwatts-projects --token=${{ secrets.VERCEL_TOKEN }}
 
+      - name: Pull Vercel Project Settings
+        run: vercel pull --yes --token=${{ secrets.VERCEL_TOKEN }}
+
       - name: Install Dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary
- Add `vercel pull --yes` step after `vercel link`
- Required for `vercel build` to access project settings

## Test plan
- [ ] Merge PR
- [ ] Create v1.0.9 tag
- [ ] Verify release workflow succeeds