### PR TITLE
fix: add contents:write permission for GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add explicit `contents: write` permission for GITHUB_TOKEN
- Required for `softprops/action-gh-release` to create releases

## Test plan
- [ ] Merge PR
- [ ] Create v1.0.10 tag
- [ ] Verify release workflow completes with GitHub release created