### PR TITLE
Remove trivial npm packages from projects

### DIFF
--- a/__tests__/lib/projects.test.ts
+++ b/__tests__/lib/projects.test.ts
@@ -110,27 +110,25 @@ describe('Projects Library', () => {
       expect(projectIds).toContain('meme-search')
       expect(projectIds).toContain('polarize')
       expect(projectIds).toContain('bleep-that-sht')
-      expect(projectIds).toContain('tfq')
-      expect(projectIds).toContain('todoq')
     })
 
-    test('projects with videos come first, npm packages come last', () => {
+    test('projects with videos come first', () => {
       const projects = getProjectsData()
 
       // Find indices
       const videoProjects = projects.filter(p => p.youtubeId)
-      const npmProjects = projects.filter(p => p.type === 'npm')
+      const nonVideoProjects = projects.filter(p => !p.youtubeId)
 
       // All video projects should be at the beginning
       videoProjects.forEach(vp => {
         const vpIndex = projects.findIndex(p => p.id === vp.id)
-        expect(vpIndex).toBeLessThan(projects.length - npmProjects.length)
+        expect(vpIndex).toBeLessThan(videoProjects.length)
       })
 
-      // All npm projects should be at the end
-      npmProjects.forEach(np => {
+      // All non-video projects should be at the end
+      nonVideoProjects.forEach(np => {
         const npIndex = projects.findIndex(p => p.id === np.id)
-        expect(npIndex).toBeGreaterThanOrEqual(projects.length - npmProjects.length)
+        expect(npIndex).toBeGreaterThanOrEqual(videoProjects.length)
       })
     })
 
@@ -158,7 +156,7 @@ describe('Projects Library', () => {
     })
 
     test('finds all projects by id', () => {
-      const projectIds = ['ytgify', 'qc', 'mybodyscans', 'meme-search', 'polarize', 'bleep-that-sht', 'tfq', 'todoq']
+      const projectIds = ['bugdrop', 'ytgify', 'qc', 'mybodyscans', 'meme-search', 'polarize', 'bleep-that-sht']
 
       projectIds.forEach(id => {
         const project = getProjectById(id)

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -93,27 +93,6 @@ const projects: ProjectData[] = [
     type: 'live',
     tags: ['Web App', 'Relationships', 'Tools'],
     lastUpdated: '2025-09-20'
-  },
-  // NPM packages (bottom)
-  {
-    id: 'tfq',
-    title: 'TFQ',
-    description: 'Test Failure Queue - Claude Code powered test debugging without context overload',
-    image: '/images/projects/npm-icon.svg',
-    link: 'https://www.npmjs.com/package/tfq',
-    type: 'npm',
-    tags: ['CLI', 'Testing', 'Claude Code', 'DevTools'],
-    lastUpdated: '2025-09-16'
-  },
-  {
-    id: 'todoq',
-    title: 'TodoQ',
-    description: 'CLI task management for Claude Code without JSON overhead',
-    image: '/images/projects/npm-icon.svg',
-    link: 'https://www.npmjs.com/package/todoq',
-    type: 'npm',
-    tags: ['CLI', 'Task Management', 'Claude Code', 'Productivity'],
-    lastUpdated: '2025-09-16'
   }
 ]
 


### PR DESCRIPTION
## Summary
- Remove TFQ and TodoQ npm packages from the projects showcase
- These were simple utilities that don't warrant showcase placement

## Test plan
- [x] All 92 tests pass