### PR TITLE
feat: add dev-only admin editor for blog posts

### DIFF
--- a/app/admin/edit/[slug]/page.tsx
+++ b/app/admin/edit/[slug]/page.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useEffect, useState, useCallback, use } from 'react'
+import dynamic from 'next/dynamic'
+
+const RawEditor = dynamic(() => import('@/components/admin/RawEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="h-[600px] flex items-center justify-center text-[var(--color-text-secondary)]">
+      Loading editor...
+    </div>
+  ),
+})
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export default function EditPostPage({ params }: PageProps) {
+  const { slug } = use(params)
+  const [content, setContent] = useState<string>('')
+  const [originalContent, setOriginalContent] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle')
+
+  const hasChanges = content !== originalContent
+
+  useEffect(() => {
+    fetch(`/api/admin/posts/${slug}`)
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to load post')
+        return res.json()
+      })
+      .then(data => {
+        setContent(data.raw)
+        setOriginalContent(data.raw)
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [slug])
+
+  // Warn about unsaved changes
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasChanges) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [hasChanges])
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    setSaveStatus('idle')
+
+    try {
+      const res = await fetch(`/api/admin/posts/${slug}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ raw: content }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to save')
+      }
+
+      setOriginalContent(content)
+      setSaveStatus('saved')
+      setTimeout(() => setSaveStatus('idle'), 2000)
+    } catch (err) {
+      setSaveStatus('error')
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }, [content, slug])
+
+  // Keyboard shortcut: Cmd/Ctrl + S to save
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault()
+        if (hasChanges && !saving) {
+          handleSave()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleSave, hasChanges, saving])
+
+  if (loading) {
+    return (
+      <div className="max-w-6xl mx-auto px-6 py-12">
+        <div className="text-[var(--color-text-secondary)]">Loading post...</div>
+      </div>
+    )
+  }
+
+  if (error && !content) {
+    return (
+      <div className="max-w-6xl mx-auto px-6 py-12">
+        <div className="text-red-400">Error: {error}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-4">
+          <a
+            href="/admin"
+            className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </a>
+          <h1 className="text-lg font-medium text-[var(--color-text-primary)] truncate max-w-md">
+            {slug}
+          </h1>
+          {hasChanges && (
+            <span className="text-xs px-2 py-1 rounded bg-amber-500/20 text-amber-400">
+              Unsaved changes
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <a
+            href={`/posts/${slug}`}
+            className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            View post
+          </a>
+          <button
+            onClick={handleSave}
+            disabled={!hasChanges || saving}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+              hasChanges && !saving
+                ? 'bg-indigo-600 hover:bg-indigo-700 text-white'
+                : 'bg-[var(--color-surface-tertiary)] text-[var(--color-text-tertiary)] cursor-not-allowed'
+            }`}
+          >
+            {saving ? 'Saving...' : saveStatus === 'saved' ? 'Saved!' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="mb-4 p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Editor */}
+      <div className="rounded-lg border border-[var(--color-border-primary)] bg-[var(--color-surface-secondary)] overflow-hidden">
+        <RawEditor
+          value={content}
+          onChange={setContent}
+        />
+      </div>
+
+      {/* Help text */}
+      <p className="mt-4 text-xs text-[var(--color-text-tertiary)]">
+        Press <kbd className="px-1.5 py-0.5 rounded bg-[var(--color-surface-tertiary)] font-mono">Cmd+S</kbd> to save
+      </p>
+    </div>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,37 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  // Dev-only gate: block access in production
+  if (process.env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--color-surface-primary)]">
+      <header className="border-b border-[var(--color-border-primary)] bg-[var(--color-surface-secondary)]">
+        <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Link href="/admin" className="text-xl font-semibold text-[var(--color-text-primary)]">
+              Admin
+            </Link>
+            <span className="text-xs px-2 py-1 rounded bg-amber-500/20 text-amber-400 font-medium">
+              Dev Only
+            </span>
+          </div>
+          <Link
+            href="/"
+            className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            View Site
+          </Link>
+        </div>
+      </header>
+      <main>{children}</main>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface PostSummary {
+  slug: string
+  title: string
+  date: string
+  excerpt: string
+  featured: boolean
+}
+
+export default function AdminPage() {
+  const [posts, setPosts] = useState<PostSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/admin/posts')
+      .then(res => res.json())
+      .then(data => {
+        setPosts(data.posts || [])
+        setLoading(false)
+      })
+      .catch(err => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        <div className="text-[var(--color-text-secondary)]">Loading posts...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        <div className="text-red-400">Error: {error}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-12">
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--color-text-primary)]">
+          Posts
+        </h1>
+        <span className="text-sm text-[var(--color-text-secondary)]">
+          {posts.length} posts
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        {posts.map(post => (
+          <a
+            key={post.slug}
+            href={`/admin/posts/${post.slug}`}
+            className="block p-4 rounded-lg border border-[var(--color-border-primary)] bg-[var(--color-surface-secondary)] hover:border-[var(--color-border-secondary)] transition-colors group"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <h2 className="font-medium text-[var(--color-text-primary)] group-hover:text-indigo-400 transition-colors truncate">
+                    {post.title}
+                  </h2>
+                  {post.featured && (
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 font-medium shrink-0">
+                      Featured
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-[var(--color-text-secondary)] truncate">
+                  {post.excerpt}
+                </p>
+              </div>
+              <time className="text-sm text-[var(--color-text-tertiary)] shrink-0">
+                {post.date}
+              </time>
+            </div>
+          </a>
+        ))}
+      </div>
+
+      {posts.length === 0 && (
+        <div className="text-center py-12 text-[var(--color-text-secondary)]">
+          No posts found
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/posts/[slug]/page.tsx
+++ b/app/admin/posts/[slug]/page.tsx
@@ -1,0 +1,129 @@
+import { notFound } from 'next/navigation'
+import { getPostData } from '@/lib/posts'
+import { format } from 'date-fns'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import Link from 'next/link'
+
+interface PreviewPageProps {
+  params: Promise<{ slug: string }>
+}
+
+export default async function AdminPreviewPage({ params }: PreviewPageProps) {
+  // Dev-only gate
+  if (process.env.NODE_ENV !== 'development') {
+    notFound()
+  }
+
+  const { slug } = await params
+  const post = await getPostData(slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  const formattedDate = format(new Date(post.date), 'MMMM d, yyyy')
+
+  return (
+    <div className="min-h-screen flex flex-col" style={{ backgroundColor: 'transparent' }}>
+      {/* Admin toolbar */}
+      <div className="sticky top-0 z-50 border-b border-[var(--color-border-primary)] bg-[var(--color-surface-secondary)]/95 backdrop-blur-sm">
+        <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Link
+              href="/admin"
+              className="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </Link>
+            <span className="text-sm text-[var(--color-text-secondary)]">Preview</span>
+            <span className="text-xs px-2 py-1 rounded bg-amber-500/20 text-amber-400 font-medium">
+              Dev Only
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/posts/${slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+            >
+              View live
+            </Link>
+            <Link
+              href={`/admin/edit/${slug}`}
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-700 text-white transition-colors"
+            >
+              Edit
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <Header />
+
+      <main className="flex-grow">
+        <article className="max-w-4xl mx-auto px-4 py-8 sm:py-12 md:py-16 lg:py-20">
+          {/* Article Header */}
+          <header className="mb-8 sm:mb-12 md:mb-16">
+            {/* Title */}
+            <h1
+              className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold mb-4 sm:mb-6 leading-tight transition-all duration-300"
+              style={{
+                color: 'var(--color-text-primary)',
+                letterSpacing: '-0.04em',
+                textShadow: '0 2px 4px rgba(0, 0, 0, 0.05)',
+              }}
+            >
+              {post.title}
+            </h1>
+
+            {/* Divider */}
+            <div
+              className="w-16 sm:w-20 md:w-24 h-px mb-4 sm:mb-6 md:mb-8 transition-all duration-300"
+              style={{ background: 'var(--gradient-subtle)' }}
+            ></div>
+
+            {/* Meta info */}
+            <div
+              className="flex flex-col sm:flex-row sm:items-center text-sm sm:text-base mb-4 sm:mb-6 md:mb-8 transition-all duration-300 gap-2 sm:gap-0 sm:space-x-8"
+              style={{ color: 'var(--color-text-secondary)' }}
+            >
+              <time dateTime={post.date} className="font-medium">
+                {formattedDate}
+              </time>
+              <span className="font-medium">{post.readingTime}</span>
+              {post.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 sm:gap-3 mt-2 sm:mt-0">
+                  {post.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="tag-badge"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </header>
+
+          {/* Article Content */}
+          <div
+            className="prose prose-base sm:prose-lg md:prose-xl max-w-none mb-10 sm:mb-16 md:mb-20 prose-content"
+            style={{
+              color: 'var(--color-text-secondary)',
+              lineHeight: '1.75',
+            }}
+          >
+            <div dangerouslySetInnerHTML={{ __html: post.content }} />
+          </div>
+        </article>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/app/api/admin/posts/[slug]/route.ts
+++ b/app/api/admin/posts/[slug]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  // Dev-only gate
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const { slug } = await params
+  const postsDirectory = path.join(process.cwd(), 'posts')
+  const fullPath = path.join(postsDirectory, `${slug}.md`)
+
+  if (!fs.existsSync(fullPath)) {
+    return NextResponse.json({ error: 'Post not found' }, { status: 404 })
+  }
+
+  const fileContents = fs.readFileSync(fullPath, 'utf8')
+  const { data: frontmatter, content } = matter(fileContents)
+
+  return NextResponse.json({
+    slug,
+    frontmatter,
+    content,
+    raw: fileContents,
+  })
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  // Dev-only gate
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const { slug } = await params
+  const postsDirectory = path.join(process.cwd(), 'posts')
+  const fullPath = path.join(postsDirectory, `${slug}.md`)
+
+  try {
+    const body = await request.json()
+    const { raw } = body
+
+    if (!raw || typeof raw !== 'string') {
+      return NextResponse.json({ error: 'Invalid content' }, { status: 400 })
+    }
+
+    // Validate that the content has valid frontmatter
+    try {
+      matter(raw)
+    } catch {
+      return NextResponse.json({ error: 'Invalid frontmatter' }, { status: 400 })
+    }
+
+    fs.writeFileSync(fullPath, raw, 'utf8')
+
+    return NextResponse.json({ success: true, slug })
+  } catch (error) {
+    console.error('Error saving post:', error)
+    return NextResponse.json({ error: 'Failed to save post' }, { status: 500 })
+  }
+}

--- a/app/api/admin/posts/route.ts
+++ b/app/api/admin/posts/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+
+export async function GET() {
+  // Dev-only gate
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const postsDirectory = path.join(process.cwd(), 'posts')
+
+  if (!fs.existsSync(postsDirectory)) {
+    return NextResponse.json({ posts: [] })
+  }
+
+  const fileNames = fs.readdirSync(postsDirectory)
+  const posts = fileNames
+    .filter(fileName => fileName.endsWith('.md'))
+    .map(fileName => {
+      const slug = fileName.replace(/\.md$/, '')
+      const fullPath = path.join(postsDirectory, fileName)
+      const fileContents = fs.readFileSync(fullPath, 'utf8')
+      const { data } = matter(fileContents)
+
+      return {
+        slug,
+        title: data.title || slug,
+        date: data.date || '',
+        excerpt: data.excerpt || '',
+        featured: data.featured || false,
+      }
+    })
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+
+  return NextResponse.json({ posts })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -91,7 +91,7 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
         <link rel="manifest" href="/manifest.json" />
       </head>
-      <body className={`${inter.variable} ${poppins.variable} ${jetbrainsMono.variable} font-sans grid-pattern`}>
+      <body className={`${inter.variable} ${poppins.variable} ${jetbrainsMono.variable} font-sans grid-pattern`} suppressHydrationWarning>
         {GA_TRACKING_ID && (
           <>
             <Script

--- a/components/admin/RawEditor.tsx
+++ b/components/admin/RawEditor.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+interface RawEditorProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export default function RawEditor({ value, onChange }: RawEditorProps) {
+  return (
+    <div className="flex flex-col h-full">
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full h-full min-h-[600px] p-6 bg-transparent text-[var(--color-text-primary)] font-mono text-sm leading-relaxed resize-none focus:outline-none"
+        spellCheck={false}
+        placeholder="---
+title: Your Post Title
+date: 2026-01-01
+---
+
+Start writing your post..."
+      />
+      <style jsx>{`
+        textarea {
+          tab-size: 2;
+        }
+        textarea::placeholder {
+          color: var(--color-text-tertiary);
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,8 @@ export default [
       'react/no-unknown-property': ['error', { ignore: ['jsx'] }],
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/immutability': 'off',
+      // Maintainability
+      'max-lines': ['warn', { max: 300, skipBlankLines: true, skipComments: true }],
     },
     settings: {
       react: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,8 @@ import createMDX from '@next/mdx'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
+  // Only use static export for production builds (allows API routes in dev for admin)
+  ...(process.env.NODE_ENV === 'production' ? { output: 'export' } : {}),
   trailingSlash: true,
   basePath: '',
   assetPrefix: '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -337,13 +337,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -636,14 +636,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3001,9 +3001,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.1.tgz",
-      "integrity": "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3038,9 +3038,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
-      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -3054,9 +3054,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz",
-      "integrity": "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
       "cpu": [
         "x64"
       ],
@@ -3070,9 +3070,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz",
-      "integrity": "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
       "cpu": [
         "arm64"
       ],
@@ -3086,9 +3086,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz",
-      "integrity": "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
       "cpu": [
         "arm64"
       ],
@@ -3102,9 +3102,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz",
-      "integrity": "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
       "cpu": [
         "x64"
       ],
@@ -3118,9 +3118,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz",
-      "integrity": "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
       "cpu": [
         "x64"
       ],
@@ -3134,9 +3134,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz",
-      "integrity": "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
       "cpu": [
         "arm64"
       ],
@@ -3150,9 +3150,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz",
-      "integrity": "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
       "cpu": [
         "x64"
       ],
@@ -5619,9 +5619,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -10892,12 +10892,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
-      "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.1",
+        "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
@@ -10911,14 +10911,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.1",
-        "@next/swc-darwin-x64": "16.1.1",
-        "@next/swc-linux-arm64-gnu": "16.1.1",
-        "@next/swc-linux-arm64-musl": "16.1.1",
-        "@next/swc-linux-x64-gnu": "16.1.1",
-        "@next/swc-linux-x64-musl": "16.1.1",
-        "@next/swc-win32-arm64-msvc": "16.1.1",
-        "@next/swc-win32-x64-msvc": "16.1.1",
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "bash scripts/build-prod.sh",
+    "build:dev": "next build",
     "start": "next start",
     "lint": "eslint app components lib types --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint app components lib types --ext .js,.jsx,.ts,.tsx --fix",

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Production build script that excludes dev-only admin routes
+
+set -e
+
+# Backup locations
+ADMIN_DIR="app/admin"
+ADMIN_API_DIR="app/api/admin"
+BACKUP_DIR=".admin-backup"
+
+# Create backup directory
+mkdir -p "$BACKUP_DIR"
+
+# Move admin pages out of the way
+if [ -d "$ADMIN_DIR" ]; then
+  echo "Moving admin pages out of build..."
+  mv "$ADMIN_DIR" "$BACKUP_DIR/admin"
+fi
+
+# Move admin API routes out of the way
+if [ -d "$ADMIN_API_DIR" ]; then
+  echo "Moving admin API routes out of build..."
+  mv "$ADMIN_API_DIR" "$BACKUP_DIR/api-admin"
+fi
+
+# Run the build
+echo "Running production build..."
+build_success=true
+next build || build_success=false
+
+# Restore admin pages
+if [ -d "$BACKUP_DIR/admin" ]; then
+  echo "Restoring admin pages..."
+  mv "$BACKUP_DIR/admin" "$ADMIN_DIR"
+fi
+
+# Restore admin API routes
+if [ -d "$BACKUP_DIR/api-admin" ]; then
+  echo "Restoring admin API routes..."
+  mv "$BACKUP_DIR/api-admin" "$ADMIN_API_DIR"
+fi
+
+# Clean up backup directory
+rmdir "$BACKUP_DIR" 2>/dev/null || true
+
+if [ "$build_success" = false ]; then
+  echo "Build failed!"
+  exit 1
+fi
+
+echo "Build complete!"


### PR DESCRIPTION
## Summary
- Add a local-only admin interface for editing blog posts directly from the browser during development
- Preview posts with full blog styling before editing
- Raw markdown editor with keyboard shortcuts

## Features
- `/admin` - Post list sorted by date
- `/admin/posts/[slug]` - Preview page matching production styling
- `/admin/edit/[slug]` - Raw markdown editor with Cmd+S save
- API routes for reading/writing post files to disk

## Security
- All admin routes gated to `NODE_ENV === 'development'`
- Production build excludes admin entirely via `scripts/build-prod.sh`
- API routes return 404 in production
- No admin code ships to production static export

## Other Changes
- Add `max-lines: 300` ESLint rule for maintainability
- Fix hydration warning caused by browser extensions
- Remove unused Milkdown packages
- Update Next.js to fix security vulnerabilities (npm audit clean)

## Test Plan
- [x] `npm run lint` passes
- [x] `npm run type-check` passes
- [x] `npm run knip` passes (no dead code)
- [x] `npm run build` succeeds (admin excluded)
- [x] Admin routes work in dev mode
- [x] Edit and save workflow verified