### PR TITLE
Add post: A Claude Code Incubator

### DIFF
--- a/posts/a-claude-code-incubator.md
+++ b/posts/a-claude-code-incubator.md
@@ -1,0 +1,57 @@
+---
+title: "A Claude Code Incubator"
+date: "2026-02-14"
+excerpt: "Anthropic just raised $30B. A small fraction could fund the Claude Code showcase the ecosystem actually needs."
+tags: ["Claude Code", "AI", "Startups", "Anthropic", "Incubator"]
+featured: true
+image: "/images/posts/claude-code-incubator.png"
+author: "Jeremy Watt"
+seoTitle: "A Claude Code Incubator: Why Anthropic Should Supercharge Early Builders"
+metaDescription: "Anthropic raised $30B. Here's why a lightweight Claude Code incubator for solo devs and small teams would do more for adoption than any benchmark."
+---
+
+# A Claude Code Incubator
+
+In the [recent Dwarkesh pod interview](https://www.youtube.com/watch?v=n1E9IZfvGMA), Dario started off bemoaning the fact that AI gains from tools like Claude Code haven't hit mainstream consciousness yet — even though their abilities have skyrocketed in the last 6 months. Dwarkesh noted that there don't seem to be many apps built with Claude Code / Codex / etc. yet, at least in public awareness.
+
+And honestly, that tracks. If you're deep in the Claude Code world, you know what it can do. But step outside the echo chamber and most people — even most developers — couldn't name a single product built primarily with it. That's a problem. Not because the tool isn't good enough, but because there's no visible proof that it is.
+
+***
+
+## The gap
+
+Anthropic just raised $30B. They have real startup programs already — and they deserve credit for them:
+
+- **The Anthology Fund** — a $100M initiative with Menlo Ventures investing in startups building on Anthropic tech, from seed to expansion stage.
+- **The VC Partner Program** — API credits and rate limits for early-stage startups backed by partner VCs.
+- **F/ai** — a joint Paris-based accelerator with OpenAI, Google, Meta, Microsoft, and Mistral, run through Station F.
+
+These are great initiatives. But they seem to serve a different purpose than what's needed here. The Anthology Fund is a traditional investment vehicle targeting funded companies. The VC Partner Program requires existing VC backing. F/ai is Europe-focused and model-agnostic — it's not about Claude Code specifically.
+
+None of these are designed to answer the question Dario and Dwarkesh were circling: **where are the publicly visible products built with Claude Code?**
+
+## The idea
+
+What if Anthropic took a tiny fraction of that $30B raise — say $10M, maybe up to $100M — and stood up a lightweight incubator specifically to supercharge the early adopters who are already trying to build companies with Claude Code?
+
+Not a VC fund. Not an API credits program. Something more targeted:
+
+- **Pre-seed and seed-level checks** ($25K–$100K) for solo devs and tiny teams who are already building with Claude Code.
+- **Full Claude Code access** and some mentorship from people who know what these tools can do.
+- **An official "Built with Claude Code" portfolio** that showcases what comes out the other end — a living, growing answer to the visibility problem.
+
+The early adopters are already out there. They're building apps, shipping products, grinding through the learning curve. Many of them don't have VC backing and aren't going to get it anytime soon — they're solo founders, two-person teams, engineers with day jobs and side projects. These are exactly the people who would benefit most from a small check and a signal boost.
+
+## Why it matters
+
+The point wouldn't be financial returns on the portfolio. The ROI is something more valuable to Anthropic right now: **proof**.
+
+Every potential enterprise customer, every developer evaluating Claude Code vs. Codex vs. Cursor, every engineering leader trying to justify the budget — they're all asking the same question: *what can I actually build with this?* Benchmarks don't answer that. Blog posts don't answer that. Fifty shipped products do.
+
+Dario himself predicted we'll see the first billion-dollar business started by a single person as soon as 2026. A Claude Code incubator would be a direct bet on making that happen — and making sure everyone sees it when it does.
+
+## The bottom line
+
+The capabilities are there. The early adopters are there. The mainstream awareness isn't — yet. A lightweight incubator wouldn't just help a few dozen builders get off the ground. It would create the visible wave of shipped products that makes the capabilities real for everyone else.
+
+The early adopters are already out there grinding. Just pour some fuel on that fire.


### PR DESCRIPTION
## Summary
- New blog post proposing Anthropic create a lightweight Claude Code incubator for solo devs and small teams
- Riffs on Dario's comments in the recent Dwarkesh pod about Claude Code capabilities not hitting mainstream awareness

## Test plan
- [ ] Verify post renders correctly on local dev
- [ ] Check frontmatter fields are complete