### PR TITLE
Fix GA tracking on Vercel and add www canonicalization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,9 @@ jobs:
 
       - name: Build with Vercel
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          NEXT_PUBLIC_GA_ID: ${{ secrets.GA_TRACKING_ID }}
+          NEXT_PUBLIC_SITE_URL: https://neonwatty.com
 
       - name: Deploy to Production
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,9 +3,14 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import StructuredData from '@/components/StructuredData'
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://neonwatty.com'
+
 export const metadata: Metadata = {
   title: 'About Jeremy',
   description: 'AI Engineer, HVAC certified technician, and Religious Studies BA passionate about building intelligent systems.',
+  alternates: {
+    canonical: `${siteUrl}/about`,
+  },
 }
 
 export default function About() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,18 @@
+import { Metadata } from 'next'
 import { getSortedPostsData } from '@/lib/posts'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import Link from 'next/link'
 import { format } from 'date-fns'
 import DevEditButton from '@/components/DevEditButton'
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://neonwatty.com'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: siteUrl,
+  },
+}
 
 export default function Home() {
   const allPostsData = getSortedPostsData()

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -10,6 +10,9 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://localhost:3000'
 export const metadata: Metadata = {
   title: 'Projects',
   description: 'Explore my recent side projects - AI tools, web apps, and open source contributions.',
+  alternates: {
+    canonical: `${siteUrl}/projects`,
+  },
   openGraph: {
     title: 'Projects | Jeremy Watt\'s Blog',
     description: 'Explore my recent side projects - AI tools, web apps, and open source contributions.',

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -50,6 +50,9 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
       images: [`${siteUrl}/images/og-image.jpg`],
       creator: '@neonwatty',
     },
+    alternates: {
+      canonical: `${siteUrl}/tags/${tag}`,
+    },
   }
 }
 

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -5,9 +5,14 @@ import Footer from '@/components/Footer'
 import StructuredData from '@/components/StructuredData'
 import { getPopularTags, getAllTags } from '@/lib/posts'
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://neonwatty.com'
+
 export const metadata: Metadata = {
   title: 'Tags',
   description: 'Explore all topics and tags covered in our blog posts.',
+  alternates: {
+    canonical: `${siteUrl}/tags`,
+  },
 }
 
 export default function TagsPage() {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "redirects": [
+    {
+      "source": "/:path(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "www.neonwatty.com"
+        }
+      ],
+      "destination": "https://neonwatty.com/:path",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **GA fix**: Pass `NEXT_PUBLIC_GA_ID` to the Vercel build step in `deploy.yml`. The GitHub Pages build already had it, but the Vercel build was missing it — causing zero GA data collection on the live site since mid-February.
- **www redirect**: Add `vercel.json` with a 301 redirect from `www.neonwatty.com` → `neonwatty.com` to stop Google from indexing both variants and splitting ranking signals.
- **Canonical URLs**: Add `alternates.canonical` metadata to home, about, projects, tags listing, and individual tag pages. Posts and project-updates already had them.

## Test plan
- [ ] Verify CI passes (type-check, lint, unit tests, e2e)
- [ ] After merge, confirm GA real-time view shows activity on neonwatty.com
- [ ] Confirm `www.neonwatty.com` 301-redirects to `neonwatty.com` (requires www domain added in Vercel dashboard)
- [ ] Check page source for `<link rel="canonical">` tags on home, about, projects, tags pages