### PR TITLE
Fix release workflow: bump Node to 22 for semantic-release@25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## Summary
- `semantic-release@25.0.3` requires Node `^22.14.0 || >= 24.10.0`
- Release workflow was using Node 20, causing every release run to fail with `node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.0`
- Bumps `node-version` from `'20'` to `'22'` in `.github/workflows/release.yml`

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, the Release workflow triggers and runs semantic-release successfully