### PR TITLE
Fix blockquote text invisible in dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -832,7 +832,7 @@
 
   .prose blockquote {
     border-left: 4px solid var(--color-accent-primary);
-    color: var(--color-text-secondary);
+    color: var(--color-text-secondary) !important;
     background: var(--color-background-tertiary);
     padding: 1rem 1.5rem;
     border-radius: 0 0.5rem 0.5rem 0;


### PR DESCRIPTION
## Summary
- Blockquote text in blog posts was invisible in dark mode — text color matched background (`#374151` on `#374151`)
- Root cause: Tailwind v4 typography plugin sets `--tw-prose-quotes` to a static dark color that doesn't respond to theme switching
- Fix: `!important` on `.prose blockquote` color to ensure our theme-aware `--color-text-secondary` wins

## Test plan
- [x] Verified dark mode: `#cbd5e1` text on `#374151` background
- [x] Verified light mode: `#374151` text on `#f1f5f9` background