### PR TITLE
Update projects page copy and LinkParty logo

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -47,14 +47,13 @@ export default function ProjectsPage() {
                 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 sm:mb-5 tracking-tight"
                 style={{ color: 'var(--color-text-primary)' }}
               >
-                Things I've Built
+                Projects
               </h1>
               <p
                 className="text-base sm:text-lg md:text-xl max-w-2xl mx-auto leading-relaxed"
                 style={{ color: 'var(--color-text-secondary)' }}
               >
-                A collection of side projects, tools, and experiments. From AI-powered apps to browser extensions and
-                CLI tools.
+                I build things to scratch my own itch. Here's what's live.
               </p>
             </div>
 

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -60,7 +60,7 @@ const projects: ProjectData[] = [
     id: 'linkparty',
     title: 'LinkParty',
     description: 'YouTube party queue app - share videos at parties without the chaos',
-    image: '/images/projects/linkparty.png',
+    image: '/images/projects/linkparty.svg',
     link: 'https://party-queue-two.vercel.app',
     type: 'live',
     tags: ['YouTube', 'Web App', 'Social'],

--- a/public/images/projects/linkparty.svg
+++ b/public/images/projects/linkparty.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <g id="background">
+    <circle cx="256" cy="256" r="248" fill="#1a1d2e"/>
+  </g>
+  <g id="broadcast-rings">
+    <circle id="ring-3" cx="256" cy="256" r="170" fill="none" stroke="#a8a4ce" stroke-width="10" stroke-opacity="0.35"/>
+    <circle id="ring-2" cx="256" cy="256" r="130" fill="none" stroke="#f4c95d" stroke-width="10" stroke-opacity="0.5"/>
+    <circle id="ring-1" cx="256" cy="256" r="90" fill="none" stroke="#ff8a5c" stroke-width="10" stroke-opacity="0.7"/>
+  </g>
+  <g id="spark-center">
+    <path id="spark" d="
+      M256,210
+      C262,240 272,244 302,256
+      C272,268 262,272 256,302
+      C250,272 240,268 210,256
+      C240,244 250,240 256,210
+      Z" fill="#ff8a5c"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Replace generic hero copy ("Things I've Built" / "A collection of side projects...") with personality-driven copy ("Projects" / "I build things to scratch my own itch. Here's what's live.")
- Replace LinkParty placeholder PNG (generic "LP" initials) with actual SVG logo (broadcast rings + spark)
- Switch LinkParty image from `.png` to `.svg` in projects config

## Test plan
- [x] Verified projects page renders updated copy
- [x] Verified LinkParty card shows new SVG logo