### PR TITLE
Add beta badges to LinkParty, QC, and Bullhorn

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -78,6 +78,11 @@ export default function ProjectCard({ project, animationDelay = 0 }: ProjectCard
               {/* Title */}
               <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white mb-2 sm:mb-3 line-clamp-2 group-hover:translate-x-1 transition-all duration-200">
                 {project.title}
+                {project.beta && (
+                  <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-500/15 text-amber-500 dark:bg-amber-400/15 dark:text-amber-400 align-middle">
+                    Beta
+                  </span>
+                )}
               </h2>
 
               {/* Description */}

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -9,6 +9,7 @@ export interface ProjectData {
   lastUpdated: string
   youtubeId?: string // YouTube video ID (e.g., "dQw4w9WgXcQ")
   youtubeIsShort?: boolean // True if the video is a YouTube Short (vertical)
+  beta?: boolean
 }
 
 const projects: ProjectData[] = [
@@ -43,6 +44,7 @@ const projects: ProjectData[] = [
     type: 'live',
     tags: ['Social Media', 'SaaS', 'Web App'],
     lastUpdated: '2026-02-23',
+    beta: true,
   },
   {
     id: 'bleep-that-sht',
@@ -65,6 +67,7 @@ const projects: ProjectData[] = [
     type: 'live',
     tags: ['YouTube', 'Web App', 'Social'],
     lastUpdated: '2026-02-23',
+    beta: true,
   },
   {
     id: 'qc',
@@ -75,6 +78,7 @@ const projects: ProjectData[] = [
     type: 'live',
     tags: ['Web App', 'Relationships', 'Tools', 'iOS'],
     lastUpdated: '2026-02-22',
+    beta: true,
   },
   {
     id: 'ytgify',


### PR DESCRIPTION
## Summary
- Add optional `beta` field to `ProjectData` interface
- Render amber "BETA" pill badge next to project title when `beta: true`
- Mark LinkParty, QC, and Bullhorn as beta

## Test plan
- [x] All three cards show amber BETA badge
- [x] Other cards unaffected
- [x] TypeScript compiles clean