### PR TITLE
Fix: add id-token:write for Claude Dependabot workflow

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` to the `claude-dependabot.yml` permissions
- Required for `claude_code_oauth_token` to exchange an OIDC token
- First run failed with: `Could not fetch an OIDC token. Did you remember to add id-token: write?`

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger the Dependabot PR #128 to verify Claude reviews it successfully