### PR TITLE
Fix: bypass OIDC for pull_request_target (claude-code-action#713)

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -45,6 +45,9 @@ jobs:
         timeout-minutes: 15
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Bypass OIDC exchange for GitHub token — pull_request_target events
+          # are rejected by Anthropic's OIDC endpoint (claude-code-action#713)
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "dependabot[bot]"
           claude_args: |
             --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git add:*),Bash(git commit:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Read,Write,Edit,Glob,Grep"


### PR DESCRIPTION
## Summary
- Passes `github_token: ${{ secrets.GITHUB_TOKEN }}` explicitly to bypass OIDC exchange
- `pull_request_target` events are rejected by Anthropic's OIDC endpoint ([claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713))
- The default `GITHUB_TOKEN` already has the required permissions from our workflow-level `permissions` block

## Context
Run 1: Failed with missing `id-token: write` (fixed in #129)
Run 2: Failed with "Invalid OIDC token" — the OIDC token was obtained but Anthropic's exchange endpoint rejects `pull_request_target` event claims

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger Dependabot PR #128 with `@dependabot rebase`
- [ ] Verify Claude successfully posts a review comment