### PR TITLE
fix: switch to pull_request trigger for OIDC + review posting

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -1,7 +1,7 @@
 name: Claude Review Dependabot PR
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 permissions:
@@ -13,7 +13,6 @@ permissions:
 jobs:
   review:
     # SECURITY: Only run for dependabot[bot] — do NOT relax this guard.
-    # pull_request_target runs with write permissions against the base repo.
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     concurrency:
@@ -21,8 +20,6 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-node@v6
         with:
@@ -45,9 +42,6 @@ jobs:
         timeout-minutes: 15
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Bypass OIDC exchange for GitHub token — pull_request_target events
-          # are rejected by Anthropic's OIDC endpoint (claude-code-action#713)
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "dependabot[bot]"
           claude_args: |
             --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git add:*),Bash(git commit:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Read,Write,Edit,Glob,Grep"


### PR DESCRIPTION
## Summary

- Switch from `pull_request_target` to `pull_request` trigger
- Remove `github_token` override so the action uses its own Claude App token via OIDC
- Remove explicit `ref` on checkout (not needed with `pull_request`)

## Why

Run 3 on PR #128 revealed the root cause: when `github_token` is provided to bypass the OIDC issue (#713), the action runs Claude successfully but **silently skips posting PR review comments**. The GITHUB_TOKEN has the right permissions (confirmed `PullRequests: write` in the logs), but the action's internal comment-posting code doesn't execute.

Switching to `pull_request` fixes both issues:
1. OIDC exchange works normally (only `pull_request_target` is rejected)
2. The action gets its own Claude App token → can post reviews as `claude[bot]`

## Required: Add Dependabot Secret

After merging, add `CLAUDE_CODE_OAUTH_TOKEN` as a **Dependabot secret**:
- Go to Settings > Secrets and variables > Actions > Dependabot tab
- Add `CLAUDE_CODE_OAUTH_TOKEN` with the same value as the repo secret

This is needed because Dependabot-triggered `pull_request` workflows can only access Dependabot secrets, not repo secrets.

## Security

Safe for Dependabot PRs: Dependabot only updates dependency versions and doesn't modify workflow files. The `github.actor == 'dependabot[bot]'` guard ensures only Dependabot PRs trigger this workflow.