### PR TITLE
fix: add gh CLI tools to Claude investigation workflow

### DIFF
--- a/.github/workflows/claude-investigate.yml
+++ b/.github/workflows/claude-investigate.yml
@@ -34,8 +34,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           label_trigger: "claude-investigate"
+          show_full_output: true
           claude_args: |
-            --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git checkout -b claude/*),Bash(git add:*),Bash(git commit:*),Bash(git branch:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Read,Write,Edit,Glob,Grep"
+            --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git checkout -b claude/*),Bash(git add:*),Bash(git commit:*),Bash(git branch:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh pr create:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep"
             --model claude-sonnet-4-5-20250929
           prompt: |
             You are investigating a bug or issue reported on this repository.


### PR DESCRIPTION
## Summary

- Add `gh` CLI commands to `--allowedTools` so Claude can create PRs, post issue comments, and manage labels
- Enable `show_full_output: true` temporarily for debugging

## Why

Run on issue #133 showed Claude ran successfully (7 turns, $0.18) but posted nothing — 3 permission denials suggest Claude tried to use `gh` commands that weren't in the allowed tools list.

Added: `gh issue comment`, `gh issue edit`, `gh pr create`, `gh label`