### PR TITLE
fix: inject issue context into Claude investigation prompt

### DIFF
--- a/.github/workflows/claude-investigate.yml
+++ b/.github/workflows/claude-investigate.yml
@@ -39,12 +39,14 @@ jobs:
             --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git checkout -b claude/*),Bash(git add:*),Bash(git commit:*),Bash(git branch:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh pr create:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep"
             --model claude-sonnet-4-5-20250929
           prompt: |
-            You are investigating a bug or issue reported on this repository.
+            You are investigating issue #${{ github.event.issue.number }}: "${{ github.event.issue.title }}"
+
+            ISSUE BODY:
+            ${{ github.event.issue.body }}
 
             STEPS:
             1. Read AGENTS.md in the repo root for project context and conventions.
-            2. Read the issue title and body to understand the problem.
-            3. Investigate the codebase to identify the root cause.
+            2. Investigate the codebase to identify the root cause based on the issue above.
             4. Implement a fix with appropriate error handling.
             5. Run `npm run lint` to check for lint errors.
             6. Run `npm run type-check` to check for type errors.


### PR DESCRIPTION
## Summary

Inject the issue number, title, and body directly into Claude's prompt using GitHub Actions expressions (`${{ github.event.issue.* }}`).

## Root cause

The custom `prompt` input replaced the action's default context-gathering behavior. Claude was running without knowing which issue to investigate — its last message in run 2 was literally: *"I need approval to check for issues with the `claude-investigate` label. Could you approve the command?"*

## Test plan

- [ ] Merge, re-trigger on issue #133, verify Claude sees the issue and acts on it