### PR TITLE
fix: broaden git push allowedTools pattern

### DIFF
--- a/.github/workflows/claude-dependabot.yml
+++ b/.github/workflows/claude-dependabot.yml
@@ -50,7 +50,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "dependabot[bot]"
           claude_args: |
-            --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git add:*),Bash(git commit:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Read,Write,Edit,Glob,Grep"
+            --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status),Read,Write,Edit,Glob,Grep"
             --model claude-sonnet-4-5-20250929
           prompt: |
             You are reviewing a Dependabot dependency update PR.

--- a/.github/workflows/claude-investigate.yml
+++ b/.github/workflows/claude-investigate.yml
@@ -36,7 +36,7 @@ jobs:
           label_trigger: "claude-investigate"
           show_full_output: true
           claude_args: |
-            --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git checkout -b claude/*),Bash(git add:*),Bash(git commit:*),Bash(git branch:*),Bash(git push origin HEAD),Bash(git diff:*),Bash(git log:*),Bash(git status),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh pr create:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep"
+            --allowedTools "Bash(npm run lint),Bash(npm run test),Bash(npm run type-check),Bash(git checkout -b claude/*),Bash(git add:*),Bash(git commit:*),Bash(git branch:*),Bash(git push:*),Bash(git diff:*),Bash(git log:*),Bash(git status),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh pr create:*),Bash(gh label:*),Read,Write,Edit,Glob,Grep"
             --model claude-sonnet-4-5-20250929
           prompt: |
             You are investigating issue #${{ github.event.issue.number }}: "${{ github.event.issue.title }}"


### PR DESCRIPTION
## Summary

- Changed `Bash(git push origin HEAD)` to `Bash(git push:*)` in both `claude-investigate.yml` and `claude-dependabot.yml`

## Root Cause

Run 3 of the investigation workflow showed Claude successfully:
1. Read the issue and AGENTS.md
2. Investigated the codebase (RawEditor.tsx, upload API)
3. Wrote a fix for the JSON parsing error handling
4. Ran lint, type-check, and tests (all passed, 272 tests)
5. Created branch `claude/fix-image-upload-error-handling` and committed

But failed at step 6: `git push origin HEAD -u` was denied because the `-u` (set-upstream) flag didn't match the exact pattern `Bash(git push origin HEAD)`.

Without the push, `gh pr create` also failed ("you must first push the current branch to a remote").

## Fix

Changed to `Bash(git push:*)` which matches any git push command variant. This is safe because the action already runs with scoped `contents: write` permissions.